### PR TITLE
Small fixes for fluxcd bootstrap

### DIFF
--- a/.configuration/flux-config.sample.env
+++ b/.configuration/flux-config.sample.env
@@ -1,6 +1,6 @@
-GITHUB_TOKEN={{ .github.token | required ".github.token is not specified in the config.yaml!" }}
-GITHUB_ORGANIZATION={{ .github.organisation | default false }}
-GITHUB_USERNAME={{ .github.username | required ".github.username is not specified in the config.yaml!" }}
-GITHUB_REPO_NAME={{ .github.repository | required ".github.repository is not specified in the config.yaml!"}}
-GITHUB_REPO_BRANCH={{ .github.branch | default "main" }}
-FLUX_NAMESPACE={{ .flux.namespace | default "flux-system" }}
+GITHUB_TOKEN={{ .gitops.github.token | required ".gitops.github.token is not specified in the config.yaml!" }}
+GITHUB_ORGANIZATION={{ .gitops.github.organisation | default false }}
+GITHUB_USERNAME={{ .gitops.github.username | required ".gitops.github.username is not specified in the config.yaml!" }}
+GITHUB_REPO_NAME={{ .gitops.github.repository | required ".gitops.github.repository is not specified in the config.yaml!"}}
+GITHUB_REPO_BRANCH={{ .gitops.github.branch | default "main" }}
+FLUX_NAMESPACE={{ .gitops.flux.namespace | default "flux-system" }}

--- a/.configuration/flux-config.sample.env
+++ b/.configuration/flux-config.sample.env
@@ -1,5 +1,5 @@
 GITHUB_TOKEN={{ .gitops.github.token | required ".gitops.github.token is not specified in the config.yaml!" }}
-GITHUB_ORGANIZATION={{ .gitops.github.organisation | default false }}
+GITHUB_PERSONAL={{ .gitops.github.personal | default true }}
 GITHUB_USERNAME={{ .gitops.github.username | required ".gitops.github.username is not specified in the config.yaml!" }}
 GITHUB_REPO_NAME={{ .gitops.github.repository | required ".gitops.github.repository is not specified in the config.yaml!"}}
 GITHUB_REPO_BRANCH={{ .gitops.github.branch | default "main" }}

--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -42,7 +42,7 @@ tasks:
         --namespace=$FLUX_NAMESPACE
         --branch=$GITHUB_REPO_BRANCH
         --path=management-clusters/$MANAGEMENT_CLUSTER/gitops
-        --personal=$GITHUB_ORGANIZATION
+        --personal=$GITHUB_PERSONAL
     preconditions:
       - sh: which flux
         msg: |-

--- a/.templates/management-clusters/gitops/kustomization.yaml
+++ b/.templates/management-clusters/gitops/kustomization.yaml
@@ -1,3 +1,4 @@
 ---
 resources:
+  - flux-system
   - gitops.yaml

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@
     │   ├── kustomization.yaml                          # management cluster main kustomization object that generates manifests
     │   ├── components                                  # management cluster components configuration
     │   │   └── k0rdent                                 # management cluster k0rdent platform installation
-    │   ├── flux                                        # management cluster Flux CD sync configs
+    │   ├── gitops                                      # management cluster Flux CD sync configs
     │   │   ├── flux-system                             # management cluster flux-system sync
-    │   │   ├── git-repository.yaml                     # management cluster flux GitRepository that is used in k0rdent flux sync configs
+    │   │   ├── gitops.yaml                             # management cluster flux GitRepository that is used in k0rdent flux sync configs
     │   │   └── k0rdent-kcm.yaml                        # management cluster k0rdent kcm component flux sync configs
     │   └── k0rdent                                     # management cluster k0rdent objects and configurations
     │      ├── cluster-deployments                      # management cluster ClusterDeployment objects directory

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -25,8 +25,8 @@ gitops:
     username: ""
     # (REQUIRED) GitOps repo name
     repository: ""
-    # Is GitOps repo owned by organisation
-    organisation: false
+    # Is GitOps repo owned by a personal account
+    personal: true
     # (REQUIRED IF YOU BOOTSTRAP FLUX USING THIS REPO) Github PAT token to bootstrap Flux
     token: ""
 


### PR DESCRIPTION
Changes:
- Add missing reference to `flux-system/` resources in template for `gitops.yaml`
- Update `config.sample.yaml` to ask for personal github account instead of organization because that's what flux cli uses
- Update `flux-config.sample.env` to use fields changed in 837efcadba9a01c482e65ca4d76dde60f4d696e8